### PR TITLE
[devOps] jenkins clone repo url 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
                     branches: [[name: '*/main']],
                     extensions: [[$class: 'SubmoduleOption', recursiveSubmodules: true, trackingSubmodules: true]],
                     userRemoteConfigs: [[
-                        url: 'https://github.com/dev-trailblazers/secrets.git',
+                        url: 'https://github.com/dev-trailblazers/study-server.git',
                         credentialsId: "${GIT_CREDENTIALS_ID}"
                     ]]
                 ])
@@ -36,9 +36,6 @@ pipeline {
         stage('Build') {
             steps {
                 script {
-                    sh 'pwd'
-                    sh 'ls -al'
-                    sh 'chmod +x ./gradlew'
                     // CI에서 테스트를 진행했기 때문에 테스트나 기타 작업을 제외하고 Jar만 생성
                     sh './gradlew clean bootJar'
                 }


### PR DESCRIPTION
./gradlew가 실패한 이유는 프로젝트 코드를 clone 한 것이 아닌 Submodule 프로젝트를 clone 했기 때문